### PR TITLE
Feat/find all

### DIFF
--- a/src/modules/store/store.controller.spec.ts
+++ b/src/modules/store/store.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { StoreController } from './store.controller';
 import { StoreService } from './store.service';
 import { DataSource } from 'typeorm';
+import { StoreTypeEnum } from '../../common/enums/store-type.enum';
 
 describe('StoreController', () => {
   let controller: StoreController;
@@ -199,5 +200,83 @@ describe('StoreController', () => {
     expect(result.storeShippings).toEqual(storeShippings);
     expect(result.pagination).toEqual(pagination);
     expect(result.total).toEqual(storeShippings.length);
+  });
+
+  it('should return all stores without pagination', async () => {
+    const stores = [
+      {
+        id: 2,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 2',
+        cep: '00000-001',
+        street: 'Rua Teste 2',
+        city: 'Cidade Teste 2',
+        number: 2,
+        neighborhood: 'Bairro Teste 2',
+        state: 'UF Teste 2',
+        uf: 'UF 2',
+        region: 'Região Teste 2',
+        lat: '1',
+        lng: '1',
+      },
+    ];
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
+
+    storeService.findAll = jest.fn().mockResolvedValue(stores);
+
+    const result = await controller.findAll(pagination);
+
+    expect(result.stores).toEqual(stores);
+    expect(result.total).toEqual(stores.length);
+  });
+
+  it('should return all stores with pagination', async () => {
+    const stores = [
+      {
+        id: 6,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 6',
+        cep: '00000-001',
+        street: 'Rua Teste 6',
+        city: 'Cidade Teste 6',
+        number: 6,
+        neighborhood: 'Bairro Teste 6',
+        state: 'UF Teste 6',
+        uf: 'UF 6',
+        region: 'Região Teste 6',
+        lat: '1',
+        lng: '1',
+      },
+      {
+        id: 7,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 7',
+        cep: '00000-001',
+        street: 'Rua Teste 7',
+        city: 'Cidade Teste 7',
+        number: 7,
+        neighborhood: 'Bairro Teste 7',
+        state: 'UF Teste 7',
+        uf: 'UF 7',
+        region: 'Região Teste 7',
+        lat: '1',
+        lng: '1',
+      },
+    ];
+    const pagination = {
+      limit: 5,
+      offset: 5,
+    };
+
+    storeService.findAll = jest.fn().mockResolvedValue(stores);
+
+    const result = await controller.findAll(pagination);
+
+    expect(result.stores).toEqual(stores);
+    expect(result.total).toBeLessThanOrEqual(pagination.limit);
+    expect(result.stores[0].id).toEqual(pagination.offset + 1);
   });
 });

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -17,7 +17,7 @@ import { ValidatePaginationInterceptor } from '../../common/interceptors/validat
 import { ShippingBodyDto } from './dtos/shipping-body.dto';
 import { OffsetValidated } from '../../common/decorators/offset-validate.decorator';
 import { Store } from './store.entity';
-import { StoreInterface } from 'src/common/interfaces/store.interface';
+import { StoreInterface } from '../../common/interfaces/store.interface';
 
 @OffsetValidated(Store)
 @UseInterceptors(ValidatePaginationInterceptor)

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -17,12 +17,25 @@ import { ValidatePaginationInterceptor } from '../../common/interceptors/validat
 import { ShippingBodyDto } from './dtos/shipping-body.dto';
 import { OffsetValidated } from '../../common/decorators/offset-validate.decorator';
 import { Store } from './store.entity';
+import { StoreInterface } from 'src/common/interfaces/store.interface';
 
 @OffsetValidated(Store)
 @UseInterceptors(ValidatePaginationInterceptor)
 @Controller('store')
 export class StoreController {
   constructor(private readonly storeService: StoreService) {}
+
+  @Get()
+  public async findAll(@Query() pagination: PaginationDto) {
+    const stores: StoreInterface[] =
+      await this.storeService.findAll(pagination);
+
+    return {
+      stores,
+      pagination,
+      total: stores.length,
+    };
+  }
 
   @ApiOperation({
     summary: 'Retorna as lojas em até 100km do CEP informado',
@@ -37,8 +50,9 @@ export class StoreController {
 
   @ApiOperation({
     summary: 'Retorna o frete para entrega de produtos ao CEP informado',
-    description:
-      "CEP deve ser informado no formato '00000000'. Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'. As dimensões do produto devem ser informadas em centímetros e o peso em kg",
+    description: `CEP deve ser informado no formato '00000000'. 
+      Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'. 
+      As dimensões do produto devem ser informadas em centímetros e o peso em kg`,
   })
   @Post('shipping/:cep')
   public async storesShipping(

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -25,6 +25,11 @@ import { StoreInterface } from '../../common/interfaces/store.interface';
 export class StoreController {
   constructor(private readonly storeService: StoreService) {}
 
+  @ApiOperation({
+    summary: 'Retorna todas as lojas',
+    description:
+      "Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'",
+  })
   @Get()
   public async findAll(@Query() pagination: PaginationDto) {
     const stores: StoreInterface[] =

--- a/src/modules/store/store.service.spec.ts
+++ b/src/modules/store/store.service.spec.ts
@@ -17,6 +17,7 @@ describe('StoreService', () => {
   beforeEach(async () => {
     storeRepositoryMock = {
       find: jest.fn(),
+      createQueryBuilder: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -692,5 +693,57 @@ describe('StoreService', () => {
     expect(logisticUtilsService.getShipping).toHaveBeenCalledTimes(1);
     expect(logisticUtilsService.deliveryTime).toHaveBeenCalledTimes(0);
     expect(result).toEqual(mockReturn);
+  });
+
+  it('should return all stores without pagination', async () => {
+    const pagination = { offset: undefined, limit: undefined };
+    const mockStores = [
+      { id: 1, name: 'Store 1' },
+      { id: 2, name: 'Store 2' },
+    ];
+
+    const createQueryBuilderMock = {
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(mockStores),
+    };
+
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
+    const result = await service.findAll(pagination);
+
+    expect(result).toEqual(mockStores);
+    expect(storeRepositoryMock.createQueryBuilder().getMany).toHaveBeenCalled();
+  });
+
+  it('should return stores with pagination', async () => {
+    const pagination = { offset: 10, limit: 5 };
+    const mockStores = [
+      { id: 1, name: 'Store 1' },
+      { id: 2, name: 'Store 2' },
+    ];
+
+    const createQueryBuilderMock = {
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(mockStores),
+    };
+
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
+    const result = await service.findAll(pagination);
+
+    expect(result).toEqual(mockStores);
+    expect(storeRepositoryMock.createQueryBuilder().skip).toHaveBeenCalledWith(
+      pagination.offset,
+    );
+    expect(storeRepositoryMock.createQueryBuilder().take).toHaveBeenCalledWith(
+      pagination.limit,
+    );
+    expect(storeRepositoryMock.createQueryBuilder().getMany).toHaveBeenCalled();
   });
 });

--- a/src/modules/store/store.service.ts
+++ b/src/modules/store/store.service.ts
@@ -105,4 +105,12 @@ export class StoreService {
 
     return storeShippings;
   }
+
+  public async findAll(pagination: PaginationDto): Promise<StoreInterface[]> {
+    return await this.storeRepository
+      .createQueryBuilder('store')
+      .skip(pagination.offset)
+      .take(pagination.limit)
+      .getMany();
+  }
 }


### PR DESCRIPTION
### O que foi feito
Endpoint para retornar todas as lojas cadastradas. Para isso foi criado e utilizado:
- Função no service stores para realizar busca, utilizando queryBuilders para fazer a paginação
- Definição da rota no controller, retornando as lojas recebidas do service, informações da paginação e total de lojas retornadas
- Testes unitários para as duas funções
- Documentação no swagger