### PR TITLE
Feat/find by key

### DIFF
--- a/src/common/pipes/uf-validation/uf-validation.pipe.spec.ts
+++ b/src/common/pipes/uf-validation/uf-validation.pipe.spec.ts
@@ -1,0 +1,48 @@
+import { BadRequestException } from '@nestjs/common';
+import { UfValidationPipe } from './uf-validation.pipe';
+
+describe('UfValidationPipe', () => {
+  it('should be defined', () => {
+    expect(new UfValidationPipe()).toBeDefined();
+  });
+
+  it('should return uf successfuly', () => {
+    const uf = 'PE';
+
+    const pipe = new UfValidationPipe();
+
+    const result = pipe.transform(uf);
+
+    expect(result).toEqual(uf);
+  });
+
+  it('should throw BadRequestExeption if UF has more than 2 letters', () => {
+    const uf = 'Pernambuco';
+
+    const pipe = new UfValidationPipe();
+
+    expect(() => pipe.transform(uf)).toThrow(
+      new BadRequestException('A UF must have two letters'),
+    );
+  });
+
+  it('should throw BadRequestExeption if UF has less than 2 letters', () => {
+    const uf = 'P';
+
+    const pipe = new UfValidationPipe();
+
+    expect(() => pipe.transform(uf)).toThrow(
+      new BadRequestException('A UF must have two letters'),
+    );
+  });
+
+  it('should throw BadRequestExeption if UF has numbers', () => {
+    const uf = '12';
+
+    const pipe = new UfValidationPipe();
+
+    expect(() => pipe.transform(uf)).toThrow(
+      new BadRequestException('A UF must have two letters'),
+    );
+  });
+});

--- a/src/common/pipes/uf-validation/uf-validation.pipe.ts
+++ b/src/common/pipes/uf-validation/uf-validation.pipe.ts
@@ -1,0 +1,14 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class UfValidationPipe implements PipeTransform {
+  transform(value: string) {
+    if (value.length !== 2 || !/[a-zA-Z]/.test(value)) {
+      throw new BadRequestException('A UF must have two letters');
+    }
+
+    value = value.toUpperCase();
+
+    return value;
+  }
+}

--- a/src/modules/store/store.controller.spec.ts
+++ b/src/modules/store/store.controller.spec.ts
@@ -279,4 +279,132 @@ describe('StoreController', () => {
     expect(result.total).toBeLessThanOrEqual(pagination.limit);
     expect(result.stores[0].id).toEqual(pagination.offset + 1);
   });
+
+  it('should return stores according to uf successfully', async () => {
+    const stores = [
+      {
+        id: 1,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 1',
+        cep: '00000-001',
+        street: 'Rua Teste 1',
+        city: 'Cidade Teste 1',
+        number: 1,
+        neighborhood: 'Bairro Teste 1',
+        state: 'UF Teste 1',
+        uf: 'PE',
+        region: 'Região Teste 1',
+        lat: '1',
+        lng: '1',
+      },
+      {
+        id: 2,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 2',
+        cep: '00000-001',
+        street: 'Rua Teste 2',
+        city: 'Cidade Teste 2',
+        number: 2,
+        neighborhood: 'Bairro Teste 2',
+        state: 'UF Teste 2',
+        uf: 'PE',
+        region: 'Região Teste 2',
+        lat: '1',
+        lng: '1',
+      },
+      {
+        id: 3,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 3',
+        cep: '00000-001',
+        street: 'Rua Teste 3',
+        city: 'Cidade Teste 3',
+        number: 3,
+        neighborhood: 'Bairro Teste 3',
+        state: 'UF Teste 3',
+        uf: 'MG',
+        region: 'Região Teste 3',
+        lat: '1',
+        lng: '1',
+      },
+    ];
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
+    const uf = 'PE';
+    const ufStores = stores.filter((store) => store.uf === uf);
+
+    storeService.findBy = jest.fn().mockResolvedValue(ufStores);
+
+    const result = await controller.findByUf(uf, pagination);
+
+    expect(result.total).toEqual(ufStores.length);
+    expect(result.stores).toEqual(ufStores);
+    result.stores.map((store) => {
+      expect(store.uf).toEqual(uf);
+    });
+  });
+
+  it('should return stores according to id successfully', async () => {
+    const stores = [
+      {
+        id: 1,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 1',
+        cep: '00000-001',
+        street: 'Rua Teste 1',
+        city: 'Cidade Teste 1',
+        number: 1,
+        neighborhood: 'Bairro Teste 1',
+        state: 'UF Teste 1',
+        uf: 'PE',
+        region: 'Região Teste 1',
+        lat: '1',
+        lng: '1',
+      },
+      {
+        id: 2,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 2',
+        cep: '00000-001',
+        street: 'Rua Teste 2',
+        city: 'Cidade Teste 2',
+        number: 2,
+        neighborhood: 'Bairro Teste 2',
+        state: 'UF Teste 2',
+        uf: 'PE',
+        region: 'Região Teste 2',
+        lat: '1',
+        lng: '1',
+      },
+      {
+        id: 3,
+        type: StoreTypeEnum.PDV,
+        name: 'Store 3',
+        cep: '00000-001',
+        street: 'Rua Teste 3',
+        city: 'Cidade Teste 3',
+        number: 3,
+        neighborhood: 'Bairro Teste 3',
+        state: 'UF Teste 3',
+        uf: 'MG',
+        region: 'Região Teste 3',
+        lat: '1',
+        lng: '1',
+      },
+    ];
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
+    const id = 1;
+    const idStores = stores.filter((store) => store.id === id);
+
+    storeService.findBy = jest.fn().mockResolvedValue(idStores);
+
+    const result = await controller.findById(id);
+
+    expect(result.id).toEqual(id);
+  });
 });

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -43,6 +43,11 @@ export class StoreController {
     };
   }
 
+  @ApiOperation({
+    summary: 'Retorna do UF informado',
+    description:
+      "Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'",
+  })
   @Get('uf/:uf')
   public async findByUf(
     @Param('uf', UfValidationPipe) uf: string,

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -18,6 +18,7 @@ import { ShippingBodyDto } from './dtos/shipping-body.dto';
 import { OffsetValidated } from '../../common/decorators/offset-validate.decorator';
 import { Store } from './store.entity';
 import { StoreInterface } from '../../common/interfaces/store.interface';
+import { UfValidationPipe } from 'src/common/pipes/uf-validation/uf-validation.pipe';
 
 @OffsetValidated(Store)
 @UseInterceptors(ValidatePaginationInterceptor)
@@ -41,6 +42,9 @@ export class StoreController {
       total: stores.length,
     };
   }
+
+  @Get('uf/:uf')
+  public async findByUf(@Param('uf', UfValidationPipe) uf: string) {}
 
   @ApiOperation({
     summary: 'Retorna as lojas em até 100km do CEP informado',

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -53,7 +53,7 @@ export class StoreController {
   public async findById(@Param('id', ParseIntPipe) id: number) {
     const stores = await this.storeService.findBy<'id'>('id', id, {
       limit: 1,
-      offset: undefined,
+      offset: null,
     });
 
     return stores[0];

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Get,
   Param,
+  ParseIntPipe,
   Post,
   Query,
   UseInterceptors,
@@ -44,7 +45,22 @@ export class StoreController {
   }
 
   @ApiOperation({
-    summary: 'Retorna do UF informado',
+    summary: 'Retorna loja com ID informado',
+    description:
+      "Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'",
+  })
+  @Get('id/:id')
+  public async findById(@Param('id', ParseIntPipe) id: number) {
+    const stores = await this.storeService.findBy<'id'>('id', id, {
+      limit: 1,
+      offset: undefined,
+    });
+
+    return stores[0];
+  }
+
+  @ApiOperation({
+    summary: 'Retorna lojas do UF informado',
     description:
       "Caso deseje utilizar o query param 'offset', é necessário utiliza-lo em conjunto com o 'limit'",
   })

--- a/src/modules/store/store.controller.ts
+++ b/src/modules/store/store.controller.ts
@@ -18,7 +18,7 @@ import { ShippingBodyDto } from './dtos/shipping-body.dto';
 import { OffsetValidated } from '../../common/decorators/offset-validate.decorator';
 import { Store } from './store.entity';
 import { StoreInterface } from '../../common/interfaces/store.interface';
-import { UfValidationPipe } from 'src/common/pipes/uf-validation/uf-validation.pipe';
+import { UfValidationPipe } from '../../common/pipes/uf-validation/uf-validation.pipe';
 
 @OffsetValidated(Store)
 @UseInterceptors(ValidatePaginationInterceptor)
@@ -44,7 +44,18 @@ export class StoreController {
   }
 
   @Get('uf/:uf')
-  public async findByUf(@Param('uf', UfValidationPipe) uf: string) {}
+  public async findByUf(
+    @Param('uf', UfValidationPipe) uf: string,
+    @Query() pagination: PaginationDto,
+  ) {
+    const stores = await this.storeService.findBy<'uf'>('uf', uf, pagination);
+
+    return {
+      stores: stores,
+      pagination,
+      total: stores.length,
+    };
+  }
 
   @ApiOperation({
     summary: 'Retorna as lojas em até 100km do CEP informado',

--- a/src/modules/store/store.service.spec.ts
+++ b/src/modules/store/store.service.spec.ts
@@ -18,7 +18,6 @@ describe('StoreService', () => {
     storeRepositoryMock = {
       find: jest.fn(),
       createQueryBuilder: jest.fn(),
-      findOne: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -749,60 +748,114 @@ describe('StoreService', () => {
   });
 
   it('should find a store by id', async () => {
+    const createQueryBuilderMock = {
+      where: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
     const store = new Store();
     const id = 1;
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
 
-    storeRepositoryMock.findOne.mockResolvedValueOnce(store);
+    createQueryBuilderMock.getMany.mockResolvedValueOnce([store]);
 
-    const result = await service.findBy<'id'>('id', id);
+    const result = await service.findBy<'id'>('id', id, pagination);
 
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
-      where: { id },
-    });
-    expect(result).toEqual(store);
+    expect(storeRepositoryMock.createQueryBuilder).toHaveBeenCalledWith(
+      'store',
+    );
+    expect(createQueryBuilderMock.where).toHaveBeenCalledWith(
+      'store.id = :value',
+      { value: id },
+    );
+    expect(createQueryBuilderMock.skip).toHaveBeenCalledWith(pagination.offset);
+    expect(createQueryBuilderMock.take).toHaveBeenCalledWith(pagination.limit);
+    expect(result).toEqual([store]);
   });
 
   it('should find a store by uf', async () => {
+    const createQueryBuilderMock = {
+      where: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
     const store = new Store();
     const uf = '12345678901';
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
 
-    storeRepositoryMock.findOne.mockResolvedValueOnce(store);
+    createQueryBuilderMock.getMany.mockResolvedValueOnce([store]);
 
-    const result = await service.findBy<'uf'>('uf', uf);
+    const result = await service.findBy<'uf'>('uf', uf, pagination);
 
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
-      where: { uf },
-    });
-    expect(result).toEqual(store);
+    expect(storeRepositoryMock.createQueryBuilder).toHaveBeenCalledWith(
+      'store',
+    );
+    expect(createQueryBuilderMock.where).toHaveBeenCalledWith(
+      'store.uf = :value',
+      { value: uf },
+    );
+    expect(createQueryBuilderMock.skip).toHaveBeenCalledWith(pagination.offset);
+    expect(createQueryBuilderMock.take).toHaveBeenCalledWith(pagination.limit);
+    expect(result).toEqual([store]);
   });
 
   it('should throw an error if the store is not found by id', async () => {
+    const createQueryBuilderMock = {
+      where: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
     const id = 1;
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
 
-    storeRepositoryMock.findOne.mockResolvedValueOnce(null);
-
-    await expect(service.findBy<'id'>('id', id)).rejects.toThrow(
+    await expect(service.findBy<'id'>('id', id, pagination)).rejects.toThrow(
       new NotFoundException(`Store not found`),
     );
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
-      where: { id },
-    });
   });
 
   it('should throw an error if the reader is not found by uf', async () => {
+    const createQueryBuilderMock = {
+      where: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn(),
+    };
+    storeRepositoryMock.createQueryBuilder = jest
+      .fn()
+      .mockReturnValue(createQueryBuilderMock);
+
     const uf = 'AM';
+    const pagination = {
+      limit: undefined,
+      offset: undefined,
+    };
 
-    storeRepositoryMock.findOne.mockResolvedValueOnce(null);
-
-    await expect(service.findBy<'uf'>('uf', uf)).rejects.toThrow(
+    await expect(service.findBy<'uf'>('uf', uf, pagination)).rejects.toThrow(
       new NotFoundException(`Store not found`),
     );
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
-    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
-      where: { uf },
-    });
   });
 });

--- a/src/modules/store/store.service.spec.ts
+++ b/src/modules/store/store.service.spec.ts
@@ -18,6 +18,7 @@ describe('StoreService', () => {
     storeRepositoryMock = {
       find: jest.fn(),
       createQueryBuilder: jest.fn(),
+      findOne: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -745,5 +746,63 @@ describe('StoreService', () => {
       pagination.limit,
     );
     expect(storeRepositoryMock.createQueryBuilder().getMany).toHaveBeenCalled();
+  });
+
+  it('should find a store by id', async () => {
+    const store = new Store();
+    const id = 1;
+
+    storeRepositoryMock.findOne.mockResolvedValueOnce(store);
+
+    const result = await service.findBy<'id'>('id', id);
+
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
+      where: { id },
+    });
+    expect(result).toEqual(store);
+  });
+
+  it('should find a store by uf', async () => {
+    const store = new Store();
+    const uf = '12345678901';
+
+    storeRepositoryMock.findOne.mockResolvedValueOnce(store);
+
+    const result = await service.findBy<'uf'>('uf', uf);
+
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
+      where: { uf },
+    });
+    expect(result).toEqual(store);
+  });
+
+  it('should throw an error if the store is not found by id', async () => {
+    const id = 1;
+
+    storeRepositoryMock.findOne.mockResolvedValueOnce(null);
+
+    await expect(service.findBy<'id'>('id', id)).rejects.toThrow(
+      new NotFoundException(`Store not found`),
+    );
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
+      where: { id },
+    });
+  });
+
+  it('should throw an error if the reader is not found by uf', async () => {
+    const uf = 'AM';
+
+    storeRepositoryMock.findOne.mockResolvedValueOnce(null);
+
+    await expect(service.findBy<'uf'>('uf', uf)).rejects.toThrow(
+      new NotFoundException(`Store not found`),
+    );
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledTimes(1);
+    expect(storeRepositoryMock.findOne).toHaveBeenCalledWith({
+      where: { uf },
+    });
   });
 });

--- a/src/modules/store/store.service.ts
+++ b/src/modules/store/store.service.ts
@@ -113,4 +113,19 @@ export class StoreService {
       .take(pagination.limit)
       .getMany();
   }
+
+  public async findBy<T extends keyof StoreInterface>(
+    key: T,
+    value: StoreInterface[T],
+  ): Promise<StoreInterface> {
+    const store = await this.storeRepository.findOne({
+      where: { [key]: value },
+    });
+
+    if (!store) {
+      throw new NotFoundException(`Store not found`);
+    }
+
+    return store;
+  }
 }

--- a/src/modules/store/store.service.ts
+++ b/src/modules/store/store.service.ts
@@ -126,7 +126,7 @@ export class StoreService {
       .take(pagination.limit)
       .getMany();
 
-    if (!store) {
+    if (!store || store.length === 0) {
       throw new NotFoundException(`Store not found`);
     }
 

--- a/src/modules/store/store.service.ts
+++ b/src/modules/store/store.service.ts
@@ -117,10 +117,14 @@ export class StoreService {
   public async findBy<T extends keyof StoreInterface>(
     key: T,
     value: StoreInterface[T],
-  ): Promise<StoreInterface> {
-    const store = await this.storeRepository.findOne({
-      where: { [key]: value },
-    });
+    pagination: PaginationDto,
+  ): Promise<StoreInterface[]> {
+    const store = await this.storeRepository
+      .createQueryBuilder('store')
+      .where(`store.${key} = :value`, { value })
+      .skip(pagination.offset)
+      .take(pagination.limit)
+      .getMany();
 
     if (!store) {
       throw new NotFoundException(`Store not found`);


### PR DESCRIPTION
### O que foi feito
Endpoints para buscas de lojas por ID e UF. Para isso foi criado e utilizado:

- Função no service de stores para buscas usando chaves da interface de lojas, onde deve ser informado qual a chave em um generic e a tipagem do valor é de acordo com o tipo da chave declarado na interface. A busca é feita utilizada queryBuilders para fazer paginação
- Pipe para validar UF recebido nos params
- Declaração dos endpoints no controller
- Testes unitários para as funções desenvolvidas
- Documentação no Swagger